### PR TITLE
Safer calculation of quorums when N is not ideal

### DIFF
--- a/adhoc/node.yaml
+++ b/adhoc/node.yaml
@@ -105,9 +105,9 @@ services:
     volumes:
       - ${SAWTOOTH_PBFT:-..}:/project/sawtooth-pbft
     working_dir: /project/sawtooth-pbft/
-    command: ./target/debug/pbft-engine --connect tcp://validator:5050 -v
+    command: ./target/debug/pbft-engine --connect tcp://validator:5050 -vv
     environment:
-      - RUST_BACKTRACE=1
+      - RUST_BACKTRACE=full
 
   rest-api:
     image: sawtooth-rest-api:${ISOLATION_ID}

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,6 +281,7 @@ pub fn get_members_from_settings<S: std::hash::BuildHasher>(
         .get("sawtooth.consensus.pbft.members")
         .expect("'sawtooth.consensus.pbft.members' is empty; this setting must exist to use PBFT");
 
+    debug!("Will parse value {:?}", members_setting_value);
     let members: Vec<String> =
         serde_json::from_str(members_setting_value).unwrap_or_else(|_err| Vec::new());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,9 @@ pub struct PbftConfig {
 
     /// Where to store PbftState ("memory" or "disk+/path/to/file")
     pub storage_location: String,
+
+    /// Whether or not to use strict quorum threshold calculation
+    pub strict_quorum: bool,
 }
 
 impl PbftConfig {
@@ -85,6 +88,7 @@ impl PbftConfig {
             forced_view_change_interval: 100,
             max_log_size: 10000,
             storage_location: "memory".into(),
+            strict_quorum: false,
         }
     }
 
@@ -97,6 +101,7 @@ impl PbftConfig {
     /// + `sawtooth.consensus.pbft.commit_timeout` (optional, default 10000 ms)
     /// + `sawtooth.consensus.pbft.view_change_duration` (optional, default 5000 ms)
     /// + `sawtooth.consensus.pbft.forced_view_change_interval` (optional, default 100 blocks)
+    /// + `sawtooth.consensus.pbft.strict_quorum` (optional, default false)
     ///
     /// # Panics
     /// + If block publishing delay is greater than the idle timeout
@@ -116,6 +121,7 @@ impl PbftConfig {
                         String::from("sawtooth.consensus.pbft.commit_timeout"),
                         String::from("sawtooth.consensus.pbft.view_change_duration"),
                         String::from("sawtooth.consensus.pbft.forced_view_change_interval"),
+                        String::from("sawtooth.consensus.pbft.strict_quorum"),
                     ],
                 )
             },
@@ -124,6 +130,9 @@ impl PbftConfig {
         // Get the on-chain list of PBFT members or panic if it is not provided; the network cannot
         // function without this setting, since there is no way of knowing which nodes are members.
         self.members = get_members_from_settings(&settings);
+
+        // get the on chain setting setting for the strict_quorum
+        self.strict_quorum = get_strict_quorum_from_settings(&settings);
 
         // Get durations
         merge_millis_setting_if_set(
@@ -199,6 +208,24 @@ fn merge_millis_setting_if_set(
         setting_key,
         Duration::from_millis,
     )
+}
+
+/// Get the strict_quorum setting from settings as a bool
+pub fn get_strict_quorum_from_settings<S: std::hash::BuildHasher>(
+    settings: &HashMap<String, String, S>,
+) -> bool {
+    match settings.get("sawtooth.consensus.pbft.strict_quorum") {
+        Some(strict_quorum_value) => {
+            if strict_quorum_value.is_empty() {
+                false
+            } else {
+                strict_quorum_value
+                    .parse()
+                    .expect("'sawtooth.consensus.pbft.strict_quorum' must be 'true' or 'false'")
+            }
+        }
+        None => false,
+    }
 }
 
 /// Get the list of PBFT members as a Vec<PeerId> from settings

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,7 +129,49 @@ impl PbftConfig {
 
         // Get the on-chain list of PBFT members or panic if it is not provided; the network cannot
         // function without this setting, since there is no way of knowing which nodes are members.
-        self.members = get_members_from_settings(&settings);
+        self.members = get_members_from_settings(&settings).unwrap_or_else(|_err| {
+            let mut done = false;
+            let mut this_block_id = block_id.clone();
+            let mut found_peers: Vec<PeerId> = Vec::new();
+            while !done {
+                let blocks = retry_until_ok(
+                    self.exponential_retry_base,
+                    self.exponential_retry_max,
+                    || service.get_blocks(vec![this_block_id.clone()]),
+                );
+                debug!("Fetching settings from prior block");
+                let previous_block_id = if let Some(current_block) = blocks.get(&this_block_id) {
+                    current_block.previous_id.clone()
+                } else {
+                    panic!("Cannot fetch the current block!");
+                };
+                let previous_settings: HashMap<String, String> = retry_until_ok(
+                    self.exponential_retry_base,
+                    self.exponential_retry_max,
+                    || {
+                        service.get_settings(
+                            previous_block_id.clone(),
+                            vec![String::from("sawtooth.consensus.pbft.members")],
+                        )
+                    },
+                );
+                match get_members_from_settings(&previous_settings) {
+                    Ok(result) => {
+                        done = true;
+                        found_peers = result;
+                    }
+                    Err(msg) => {
+                        debug!(
+                            "Valid membership not found yet, searching backward {:?}",
+                            msg
+                        );
+                        done = false;
+                        this_block_id = previous_block_id.clone();
+                    }
+                };
+            }
+            found_peers
+        });
 
         // get the on chain setting setting for the strict_quorum
         self.strict_quorum = get_strict_quorum_from_settings(&settings);
@@ -234,24 +276,26 @@ pub fn get_strict_quorum_from_settings<S: std::hash::BuildHasher>(
 /// + If the `sawtooth.consenus.pbft.members` setting is unset or invalid
 pub fn get_members_from_settings<S: std::hash::BuildHasher>(
     settings: &HashMap<String, String, S>,
-) -> Vec<PeerId> {
+) -> Result<Vec<PeerId>, &'static str> {
     let members_setting_value = settings
         .get("sawtooth.consensus.pbft.members")
         .expect("'sawtooth.consensus.pbft.members' is empty; this setting must exist to use PBFT");
 
-    let members: Vec<String> = serde_json::from_str(members_setting_value).unwrap_or_else(|err| {
-        panic!(
-            "Unable to parse value at 'sawtooth.consensus.pbft.members' due to error: {:?}",
-            err
-        )
-    });
+    let members: Vec<String> =
+        serde_json::from_str(members_setting_value).unwrap_or_else(|_err| Vec::new());
 
-    members
+    if members.is_empty() {
+        return Err(
+            "Unable to parse value at 'sawtooth.consensus.pbft.members' due to error parsing",
+        );
+    };
+
+    Ok(members
         .into_iter()
         .map(|s| {
             hex::decode(s).unwrap_or_else(|err| {
                 panic!("Unable to parse PeerId from string due to error: {:?}", err)
             })
         })
-        .collect()
+        .collect())
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -17,6 +17,7 @@
 
 //! The core PBFT algorithm
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::From;
 
@@ -1030,7 +1031,49 @@ impl PbftNode {
         );
 
         let strict_quorum = get_strict_quorum_from_settings(&settings);
-        let on_chain_members = get_members_from_settings(&settings);
+        let on_chain_members = get_members_from_settings(&settings).unwrap_or_else(|_err| {
+            let mut done = false;
+            let mut this_block_id = block_id.clone();
+            let mut found_peers: Vec<PeerId> = Vec::new();
+            while !done {
+                let blocks = retry_until_ok(
+                    state.exponential_retry_base,
+                    state.exponential_retry_max,
+                    || self.service.get_blocks(vec![this_block_id.clone()]),
+                );
+                debug!("Fetching settings from prior block");
+                let previous_block_id = if let Some(current_block) = blocks.get(&this_block_id) {
+                    current_block.previous_id.clone()
+                } else {
+                    panic!("Cannot fetch the current block!");
+                };
+                let previous_settings: HashMap<String, String> = retry_until_ok(
+                    state.exponential_retry_base,
+                    state.exponential_retry_max,
+                    || {
+                        self.service.get_settings(
+                            previous_block_id.clone(),
+                            vec![String::from("sawtooth.consensus.pbft.members")],
+                        )
+                    },
+                );
+                match get_members_from_settings(&previous_settings) {
+                    Ok(result) => {
+                        done = true;
+                        found_peers = result;
+                    }
+                    Err(msg) => {
+                        debug!(
+                            "Valid membership not found yet, searching backward {:?}",
+                            msg
+                        );
+                        done = false;
+                        this_block_id = previous_block_id.clone();
+                    }
+                };
+            }
+            found_peers
+        });
 
         if on_chain_members != state.member_ids {
             info!("Updating membership: {:?}", on_chain_members);
@@ -1518,7 +1561,49 @@ impl PbftNode {
                 )
             },
         );
-        let members = get_members_from_settings(&settings);
+        let members = get_members_from_settings(&settings).unwrap_or_else(|_err| {
+            let mut done = false;
+            let mut this_block_id = previous_id.clone();
+            let mut found_peers: Vec<PeerId> = Vec::new();
+            while !done {
+                let blocks = retry_until_ok(
+                    state.exponential_retry_base,
+                    state.exponential_retry_max,
+                    || self.service.get_blocks(vec![this_block_id.clone()]),
+                );
+                debug!("Fetching settings from prior block");
+                let previous_block_id = if let Some(current_block) = blocks.get(&this_block_id) {
+                    current_block.previous_id.clone()
+                } else {
+                    panic!("Cannot fetch the current block!");
+                };
+                let previous_settings: HashMap<String, String> = retry_until_ok(
+                    state.exponential_retry_base,
+                    state.exponential_retry_max,
+                    || {
+                        self.service.get_settings(
+                            previous_block_id.clone(),
+                            vec![String::from("sawtooth.consensus.pbft.members")],
+                        )
+                    },
+                );
+                match get_members_from_settings(&previous_settings) {
+                    Ok(result) => {
+                        done = true;
+                        found_peers = result;
+                    }
+                    Err(msg) => {
+                        debug!(
+                            "Valid membership not found yet, searching backward {:?}",
+                            msg
+                        );
+                        done = false;
+                        this_block_id = previous_block_id.clone();
+                    }
+                };
+            }
+            found_peers
+        });
 
         // Verify that the seal's signer is a PBFT member
         if !members.contains(&seal.get_info().get_signer_id().to_vec()) {

--- a/src/node.rs
+++ b/src/node.rs
@@ -75,6 +75,18 @@ impl PbftNode {
             if let Ok(seal) = protobuf::parse_from_bytes::<PbftSeal>(&chain_head.payload) {
                 state.view = seal.get_info().get_view();
                 info!("Updated view to {} on startup", state.view);
+                if match state.phase {
+                    PbftPhase::Finishing(_) => true,
+                    _ => false,
+                } {
+                    state.phase = PbftPhase::PrePreparing;
+                }
+                if match state.mode {
+                    PbftMode::ViewChanging(_) => true,
+                    _ => false,
+                } {
+                    state.mode = PbftMode::Normal;
+                }
             }
             // If connected to any peers already, send bootstrap commit messages to them
             for peer in connected_peers {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1626,12 +1626,14 @@ impl PbftNode {
             .filter(|pid| pid.as_slice() != seal.get_info().get_signer_id())
             .collect();
 
-        trace!(
+        debug!("Original member list is ({:?})", members);
+        debug!(
             "Comparing voter IDs ({:?}) with on-chain member IDs - primary ({:?})",
             voter_ids,
             peer_ids
         );
-
+        debug!("Seal was signed by: {:?}", seal.get_info().get_signer_id());
+        
         if !voter_ids.is_subset(&peer_ids) {
             return Err(PbftError::InvalidMessage(format!(
                 "Consensus seal contains vote(s) from invalid ID(s): {:?}",

--- a/src/node.rs
+++ b/src/node.rs
@@ -1629,11 +1629,10 @@ impl PbftNode {
         debug!("Original member list is ({:?})", members);
         debug!(
             "Comparing voter IDs ({:?}) with on-chain member IDs - primary ({:?})",
-            voter_ids,
-            peer_ids
+            voter_ids, peer_ids
         );
         debug!("Seal was signed by: {:?}", seal.get_info().get_signer_id());
-        
+
         if !voter_ids.is_subset(&peer_ids) {
             return Err(PbftError::InvalidMessage(format!(
                 "Consensus seal contains vote(s) from invalid ID(s): {:?}",
@@ -1661,6 +1660,13 @@ impl PbftNode {
         // on every engine loop, even if it's not yet ready. This isn't an error,
         // so just return Ok(()).
         if !state.is_primary() || state.phase != PbftPhase::PrePreparing {
+            return Ok(());
+        }
+
+        if match state.mode {
+            PbftMode::ViewChanging(_) => true,
+            _ => false,
+        } {
             return Ok(());
         }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -75,19 +75,22 @@ impl PbftNode {
             // If starting up with a block that has a consensus seal, update the view to match
             if let Ok(seal) = protobuf::parse_from_bytes::<PbftSeal>(&chain_head.payload) {
                 state.view = seal.get_info().get_view();
+
                 info!("Updated view to {} on startup", state.view);
-                if match state.phase {
-                    PbftPhase::Finishing(_) => true,
-                    _ => false,
-                } {
-                    state.phase = PbftPhase::PrePreparing;
-                }
-                if match state.mode {
-                    PbftMode::ViewChanging(_) => true,
-                    _ => false,
-                } {
-                    state.mode = PbftMode::Normal;
-                }
+                state.phase = PbftPhase::PrePreparing;
+                state.mode = PbftMode::Normal;
+                // if match state.phase {
+                //     PbftPhase::Finishing(_) => true,
+                //     _ => false,
+                // } {
+                //     state.phase = PbftPhase::PrePreparing;
+                // }
+                // if match state.mode {
+                //     PbftMode::ViewChanging(_) => true,
+                //     _ => false,
+                // } {
+                //     state.mode = PbftMode::Normal;
+                // }
             }
             // If connected to any peers already, send bootstrap commit messages to them
             for peer in connected_peers {
@@ -99,11 +102,11 @@ impl PbftNode {
         }
 
         // Primary initializes a block
-        if state.is_primary() {
-            n.service.initialize_block(None).unwrap_or_else(|err| {
-                error!("Couldn't initialize block on startup due to error: {}", err)
-            });
-        }
+        //if state.is_primary() {
+        //    n.service.initialize_block(None).unwrap_or_else(|err| {
+        //        error!("Couldn't initialize block on startup due to error: {}", err)
+        //    });
+        //}
         n
     }
 
@@ -2216,16 +2219,11 @@ mod tests {
         .write_to_bytes()
         .expect("Failed to write seal to bytes");
 
-        // Verify chain head is added to the log, chain head and view are set, and primary calls
-        // Service::initialize_block()
+        // Verify chain head is added to the log, chain head and view are set
         let (node1, state1, service1) = mock_node(&mock_config(4), vec![1], head.clone());
         assert!(node1.msg_log.get_block_with_id(&head.block_id).is_some());
         assert_eq!(vec![2], state1.chain_head);
         assert_eq!(1, state1.view);
-        assert!(service1.was_called_with_args(stringify_func_call!(
-            "initialize_block",
-            None as Option<BlockId>
-        )));
 
         // Verify non-primary does not call Service::initialize_block()
         let (_, _, service0) = mock_node(&mock_config(4), vec![0], head.clone());

--- a/src/node.rs
+++ b/src/node.rs
@@ -125,6 +125,7 @@ impl PbftNode {
             _ => false,
         } && msg_type != PbftMessageType::ViewChange
             && msg_type != PbftMessageType::NewView
+            && msg_type != PbftMessageType::SealRequest
         {
             debug!(
                 "{}: Node is view changing; ignoring {} message",

--- a/src/node.rs
+++ b/src/node.rs
@@ -840,19 +840,6 @@ impl PbftNode {
             self.msg_log.add_message(message.clone());
         }
 
-        //On startup the validator may send BlockValid for the chain head
-        // We should skip asking for a commit of this one, since it will
-        // never happen.
-        if seal.block_id == state.chain_head {
-            info!(
-                "{}: Block {} is the chain head, skipping commit and incrementing seq_num",
-                state,
-                hex::encode(&seal.block_id)
-            );
-            state.seq_num += 1;
-            return Ok(());
-        }
-
         // Commit the block, stop the idle timeout, and skip straight to Finishing
         self.service
             .commit_block(seal.block_id.clone())
@@ -866,8 +853,20 @@ impl PbftNode {
                     err,
                 )
             })?;
-        state.idle_timeout.stop();
+
         state.phase = PbftPhase::Finishing(catchup_again);
+        // On startup the validator may send BlockValid for the chain head
+        // We need to skip waiting for a commit of this one, since it will
+        // never happen.
+        if seal.block_id == state.chain_head {
+            info!(
+                "{}: Block {} is the chain head, skipping commit and incrementing seq_num",
+                state,
+                hex::encode(&seal.block_id)
+            );
+            self.on_block_commit(seal.block_id.clone(), state);
+        }
+        state.idle_timeout.stop();
 
         Ok(())
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -28,7 +28,7 @@ use sawtooth_sdk::consensus::service::Service;
 use sawtooth_sdk::messages::consensus::ConsensusPeerMessageHeader;
 use sawtooth_sdk::signing::{create_context, secp256k1::Secp256k1PublicKey};
 
-use crate::config::{get_members_from_settings, PbftConfig};
+use crate::config::{get_members_from_settings, get_strict_quorum_from_settings, PbftConfig};
 use crate::error::PbftError;
 use crate::hash::verify_sha512;
 use crate::message_log::PbftLog;
@@ -222,7 +222,7 @@ impl PbftNode {
     /// Handle a `Prepare` message
     ///
     /// Once a `Prepare` for the current sequence number is accepted and added to the log, the node
-    /// will check if it has the required 2f + 1 `Prepared` messages to move on to the Committing
+    /// will check if it has the required minimum_quorum + 1 `Prepared` messages to move on to the Committing
     /// phase
     fn handle_prepare(
         &mut self,
@@ -256,7 +256,7 @@ impl PbftNode {
         // phase, check if the node is ready to move on to the Committing phase
         if info.get_seq_num() == state.seq_num && state.phase == PbftPhase::Preparing {
             // The node is ready to move on to the Committing phase (i.e. the predicate `prepared`
-            // is true) when its log has 2f + 1 Prepare messages from different nodes that match
+            // is true) when its log has minimum_quorum Prepare messages from different nodes that match
             // the PrePrepare message received earlier (same view, sequence number, and block)
             let has_matching_pre_prepare =
                 self.msg_log
@@ -270,9 +270,10 @@ impl PbftNode {
                     info.get_view(),
                     &block_id,
                 )
-                // Check if there are at least 2f + 1 Prepares
+                // Check if there are at least mimumum_quorum Prepares
+                // PrePrepare counts as leader's vote
                 .len() as u64
-                > 2 * state.f;
+                >= state.minimum_quorum();
             if has_matching_pre_prepare && has_required_prepares {
                 state.switch_phase(PbftPhase::Committing)?;
                 self.broadcast_pbft_message(
@@ -291,7 +292,7 @@ impl PbftNode {
     /// Handle a `Commit` message
     ///
     /// Once a `Commit` for the current sequence number is accepted and added to the log, the node
-    /// will check if it has the required 2f + 1 `Commit` messages to actually commit the block
+    /// will check if it has the required minimum_quorum + 1 `Commit` messages to actually commit the block
     fn handle_commit(
         &mut self,
         msg: ParsedMessage,
@@ -315,7 +316,7 @@ impl PbftNode {
         // phase, check if the node is ready to commit the block
         if info.get_seq_num() == state.seq_num && state.phase == PbftPhase::Committing {
             // The node is ready to commit the block (i.e. the predicate `committable` is true)
-            // when its log has 2f + 1 Commit messages from different nodes that match the
+            // when its log has minimum_quorum + 1 Commit messages from different nodes that match the
             // PrePrepare message received earlier (same view, sequence number, and block)
             let has_matching_pre_prepare =
                 self.msg_log
@@ -329,9 +330,9 @@ impl PbftNode {
                     info.get_view(),
                     &block_id,
                 )
-                // Check if there are at least 2f + 1 Commits
+                // Check if there are at least minimum_quorum + 1 Commits
                 .len() as u64
-                > 2 * state.f;
+                > state.minimum_quorum();
             if has_matching_pre_prepare && has_required_commits {
                 self.service.commit_block(block_id.clone()).map_err(|err| {
                     PbftError::ServiceError(
@@ -352,8 +353,8 @@ impl PbftNode {
     ///
     /// When a `ViewChange` is received, check that it isn't outdated and add it to the log. If the
     /// node isn't already view changing but it now has f + 1 ViewChange messages, start view
-    /// changing early. If the node is the primary and has 2f view change messages now, broadcast
-    /// the NewView message to the rest of the nodes to move to the new view.
+    /// changing early. If the node is the primary and has at least minimum_quorum view change
+    /// messages now, broadcast the NewView message to the rest of the nodes to move to the new view.
     fn handle_view_change(
         &mut self,
         msg: &ParsedMessage,
@@ -402,9 +403,10 @@ impl PbftNode {
             .msg_log
             .get_messages_of_type_view(PbftMessageType::ViewChange, msg_view);
 
-        // If there are 2f + 1 ViewChange messages and the view change timeout is not already
+        // If there are minimum_quorum + 1 ViewChange messages and the view change timeout is not already
         // started, update the timeout and start it
-        if !state.view_change_timeout.is_active() && messages.len() as u64 > state.f * 2 {
+        if !state.view_change_timeout.is_active() && messages.len() as u64 > state.minimum_quorum()
+        {
             state.view_change_timeout = Timeout::new(
                 state
                     .view_change_duration
@@ -414,7 +416,7 @@ impl PbftNode {
             state.view_change_timeout.start();
         }
 
-        // If this node is the new primary and the required 2f ViewChange messages (not including
+        // If this node is the new primary and the required minimum_quorum ViewChange messages (not including
         // the primary's own) are present in the log, broadcast the NewView message
         let messages_from_other_nodes = messages
             .iter()
@@ -423,7 +425,7 @@ impl PbftNode {
             .collect::<Vec<_>>();
 
         if state.is_primary_at_view(msg_view)
-            && messages_from_other_nodes.len() as u64 >= 2 * state.f
+            && messages_from_other_nodes.len() as u64 >= state.minimum_quorum()
         {
             let mut new_view = PbftNewView::new();
 
@@ -975,10 +977,15 @@ impl PbftNode {
             || {
                 self.service.get_settings(
                     block_id.clone(),
-                    vec![String::from("sawtooth.consensus.pbft.members")],
+                    vec![
+                        String::from("sawtooth.consensus.pbft.members"),
+                        String::from("sawtooth.consensus.pbft.strict_quorum"),
+                    ],
                 )
             },
         );
+
+        let strict_quorum = get_strict_quorum_from_settings(&settings);
         let on_chain_members = get_members_from_settings(&settings);
 
         if on_chain_members != state.member_ids {
@@ -988,6 +995,7 @@ impl PbftNode {
             if f == 0 {
                 panic!("This network no longer contains enough nodes to be fault tolerant");
             }
+            state.strict_quorum = strict_quorum;
             state.f = f as u64;
         }
     }
@@ -1049,7 +1057,7 @@ impl PbftNode {
     /// have the `Commit` messages necessary to build the consensus seal for the last committed
     /// block (the chain head). To bootstrap the network in this scenario, all nodes will send a
     /// `Commit` message for their chain head whenever one of the PBFT members connects; when
-    /// > 2f + 1 nodes have connected and received these `Commit` messages, the nodes will be able
+    /// > minimum_quorum + 1 nodes have connected and received these `Commit` messages, the nodes will be able
     /// to build a seal using the messages.
     fn broadcast_bootstrap_commit(
         &mut self,
@@ -1134,7 +1142,7 @@ impl PbftNode {
         trace!("{}: Building seal for block {}", state, state.seq_num - 1);
 
         // The previous block may have been committed in a different view, so the node will need to
-        // find the view that contains the required 2f Commit messages for building the seal
+        // find the view that contains the required minimum_quorum Commit messages for building the seal
         let (block_id, view, messages) = self
             .msg_log
             .get_messages_of_type_seq(PbftMessageType::Commit, state.seq_num - 1)
@@ -1151,7 +1159,7 @@ impl PbftNode {
             // One and only one block/view should have the required number of messages, since only
             // one block at this sequence number should have been committed and in only one view
             .find_map(|((block_id, view), msgs)| {
-                if msgs.len() as u64 >= 2 * state.f {
+                if msgs.len() as u64 >= state.minimum_quorum() {
                     Some((block_id, view, msgs))
                 } else {
                     None
@@ -1159,7 +1167,7 @@ impl PbftNode {
             })
             .ok_or_else(|| {
                 PbftError::InternalError(String::from(
-                    "Couldn't find 2f commit messages in the message log for building a seal",
+                    "Couldn't find the minimum_quorum commit messages in the message log for building a seal",
                 ))
             })?;
 
@@ -1333,11 +1341,11 @@ impl PbftNode {
             )));
         }
 
-        // Check that the NewView contains 2f votes (primary vote is implicit, so total of 2f + 1)
-        if (voter_ids.len() as u64) < 2 * state.f {
+        // Check that the NewView contains minimumum_quorum votes (primary vote is implicit, so total of minimum_quorum + 1)
+        if (voter_ids.len() as u64) < state.minimum_quorum() {
             return Err(PbftError::InvalidMessage(format!(
                 "NewView needs {} votes, but only {} found",
-                2 * state.f,
+                state.minimum_quorum(),
                 voter_ids.len()
             )));
         }
@@ -1490,11 +1498,11 @@ impl PbftNode {
             )));
         }
 
-        // Check that the seal contains 2f votes (primary vote is implicit, so total of 2f + 1)
-        if (voter_ids.len() as u64) < 2 * state.f {
+        // Check that the seal contains minimum_quorum votes (primary vote is implicit, so total of minimum_quorum + 1)
+        if (voter_ids.len() as u64) < state.minimum_quorum() {
             return Err(PbftError::InvalidMessage(format!(
                 "Consensus seal needs {} votes, but only {} found",
-                2 * state.f,
+                state.minimum_quorum(),
                 voter_ids.len()
             )));
         }
@@ -1679,7 +1687,7 @@ impl PbftNode {
         state.idle_timeout.stop();
         state.commit_timeout.stop();
 
-        // Stop the view change timeout if it is already active (will be restarted when 2f + 1
+        // Stop the view change timeout if it is already active (will be restarted when minimum_quorum + 1
         // ViewChange messages for the new view are received)
         state.view_change_timeout.stop();
 
@@ -2218,7 +2226,7 @@ mod tests {
     /// 5. None of the votes are from the new primary that sent this `NewView` message (the
     ///    `NewView` message is an implicit vote from the new primary, so including its own vote
     ///    would be double-voting)
-    /// 6. There are `2f` votes (again, this is really `2f + 1` since the `NewView` message itself
+    /// 6. There are `minimum_quorum` votes (again, this is really `minimum_quorum + 1` since the `NewView` message itself
     ///    is an implicit vote)
     ///
     /// This test ensures that the `verify_new_view` method properly checks the validity of
@@ -2362,7 +2370,7 @@ mod tests {
     ///    `verify_consensus_seal` method)
     /// 3. None of the votes are from the seal’s signer (producing a seal is an implicit vote from
     ///    the node that constructed it, so including its own vote would be double-voting)
-    /// 4. There are `2f` votes (this is really `2f + 1` voters since the consensus seal itself is
+    /// 4. There are `minimum_quorum` votes (this is really `minimum_quorum + 1` voters since the consensus seal itself is
     ///    an implicit vote)
     ///
     /// This test ensures that the `verify_consensus_seal` method properly checks the validity of
@@ -2634,14 +2642,14 @@ mod tests {
     /// committed. To build the seal, the node will have to have in its log:
     ///
     /// 1. The previously committed block, which has `block_num = state.seq_num - 1`
-    /// `2f + 1` matching Commit messages for the previously committed block (same type, seq_num,
+    /// `minimum_quorum + 1` matching Commit messages for the previously committed block (same type, seq_num,
     /// view, and block_id) that are from different nodes (different signer_id’s)
     ///
-    /// While the `2f + 1` messages must all have a matching view, they could be from any past view
+    /// While the `minimum_quorum + 1` messages must all have a matching view, they could be from any past view
     /// since the block could have been committed in any past view.
     ///
     /// Consensus seals are built using the `PbftNode::build_seal` method, which checks its log for
-    /// `2f` matching Commit messages for the last committed block that are from other nodes
+    /// `minimum_quorum` matching Commit messages for the last committed block that are from other nodes
     /// (doesn’t include own vote, since the seal itself is an implicit vote) and also retrieves
     /// the view the block was committed in.
     ///
@@ -2717,11 +2725,11 @@ mod tests {
             .expect("Failed to parse vote"),
         );
 
-        // Verify that seal cannot be built yet (have 2f matching messages for a block at the last
+        // Verify that seal cannot be built yet (have minimum_quorum matching messages for a block at the last
         // seq_num from different signers, but one is the seal signer's own)
         assert!(node.build_seal(&mut state).is_err());
 
-        // Add another Commit message so there are 2f matching messages from other nodes
+        // Add another Commit message so there are minimum_quorum matching messages from other nodes
         node.msg_log.add_message(
             ParsedMessage::from_signed_vote(&mock_vote(
                 PbftMessageType::Commit,
@@ -3618,7 +3626,7 @@ mod tests {
     ///
     /// 1. The node is in the Preparing phase
     /// 2. The node has a valid `PrePrepare` for the current view and sequence number
-    /// 3. The node has `2f + 1` `Prepare` messages that match the `PrePrepare` (same view,
+    /// 3. The node has `minimum_quorum + 1` `Prepare` messages that match the `PrePrepare` (same view,
     ///     sequence number, and block ID) for the node’s current sequence number, all from
     ///     different nodes
     ///
@@ -3708,7 +3716,7 @@ mod tests {
             .is_ok());
         assert_eq!(PbftPhase::Preparing, state.phase);
 
-        // Verify that there must be a matching PrePrepare (even after 2f + 1 Prepares)
+        // Verify that there must be a matching PrePrepare (even after minimum_quorum + 1 Prepares)
         assert!(node
             .on_peer_message(
                 mock_msg(PbftMessageType::Prepare, 0, 1, vec![4], vec![1], false),
@@ -3759,7 +3767,7 @@ mod tests {
     ///
     /// 1. The node is in the Committing phase
     /// 2. The node has a valid `PrePrepare` for the current view and sequence number
-    /// 3. The node has `2f + 1` `Commit` messages that match the `PrePrepare` (same view, sequence
+    /// 3. The node has `minimum_quorum + 1` `Commit` messages that match the `PrePrepare` (same view, sequence
     ///    number, and block ID) for the node’s current sequence number, all from different nodes
     ///
     /// These conditions are checked when the node receives a `Commit` message; thus, receiving a
@@ -3845,7 +3853,7 @@ mod tests {
             .is_ok());
         assert_eq!(PbftPhase::Committing, state.phase);
 
-        // Verify that there must be a matching PrePrepare (even after 2f + 1 Commits)
+        // Verify that there must be a matching PrePrepare (even after minimum_quorum + 1 Commits)
         assert!(node
             .on_peer_message(
                 mock_msg(PbftMessageType::Commit, 0, 1, vec![3], vec![1], false),
@@ -4295,18 +4303,18 @@ mod tests {
     ///
     /// These conditions ensure that no old (stale) view change messages are added to the log.
     ///
-    /// When a node has `2f + 1` `ViewChange` messages for a view, it will start its view change
+    /// When a node has `minimum_quorum + 1` `ViewChange` messages for a view, it will start its view change
     /// timeout to ensure that the new primary produces a `NewView` in a reasonable amount of time.
     /// The appropriate duration of the view change timeout is calculated based on a base duration
     /// (defined by the state object’s `view_change_duration` field) using the formula: `(desired
     /// view number - node’s current view number) * view_change_duration`.
     ///
-    /// When the new primary for the view specified in the `ViewChange` message has `2f + 1`
+    /// When the new primary for the view specified in the `ViewChange` message has `minimum_quorum + 1`
     /// `ViewChange` messages for that view, it will broadcast a `NewView` message to the network.
     /// Only the new primary should broadcast the `NewView` message.
     ///
     /// This test ensures that only non-stale `ViewChange` messages are accepted, nodes start their
-    /// view change timeouts with the appropriate duration when `2f + 1` `ViewChange` messages are
+    /// view change timeouts with the appropriate duration when `minimum_quorum + 1` `ViewChange` messages are
     /// received, and that the new primary (and only the new primary) broadcasts a `NewView` when
     /// it has the required messages in its log.
     #[test]
@@ -4352,7 +4360,7 @@ mod tests {
                 .len()
         );
 
-        // Verify NewView is not broadcasted by new primary when there aren't 2f + 1 ViewChanges
+        // Verify NewView is not broadcasted by new primary when there aren't minimum_quorum + 1 ViewChanges
         state.mode = PbftMode::ViewChanging(4);
         assert!(node
             .on_peer_message(
@@ -4368,7 +4376,7 @@ mod tests {
             .is_ok());
         assert!(!service.was_called_with_args(stringify_func_call!("broadcast", "NewView")));
 
-        // Verify NewView is broadcasted by new primary when there are 2f + 1 ViewChanges
+        // Verify NewView is broadcasted by new primary when there are minimum_quorum + 1 ViewChanges
         node.on_peer_message(
             mock_msg(PbftMessageType::ViewChange, 4, 0, vec![2], vec![], false),
             &mut state,
@@ -4406,7 +4414,7 @@ mod tests {
         );
 
         // Verify view change timeout uses the appropriate duration, and that it is not started
-        // until 2f + 1 ViewChanges are received
+        // until minimum_quorum + 1 ViewChanges are received
         state.view_change_timeout.stop();
         state.mode = PbftMode::ViewChanging(6);
         assert!(node
@@ -4438,7 +4446,7 @@ mod tests {
         );
     }
 
-    /// When the node that will become primary as the result of a view change has accepted `2f + 1`
+    /// When the node that will become primary as the result of a view change has accepted `minimum_quorum + 1`
     /// matching `ViewChange` messages for the new view, it will construct a `NewView` message that
     /// contains the required `ViewChange` messages and broadcast it to the network. When a node
     /// receives this `NewView` message, it will check that the message is valid (as determined by
@@ -5026,7 +5034,7 @@ mod tests {
     /// have the `Commit` messages necessary to build the consensus seal for the last committed
     /// block (the chain head). To bootstrap the network in this scenario, all nodes will send a
     /// `Commit` message for their chain head whenever one of the PBFT members connects; when
-    /// > 2f + 1 nodes have connected and received these `Commit` messages, the nodes will be able
+    /// > minimum_quorum + 1 nodes have connected and received these `Commit` messages, the nodes will be able
     /// to build a seal using the messages.
     #[test]
     #[allow(unused_must_use)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1614,8 +1614,8 @@ impl PbftNode {
         // Verify that the seal's signer is a PBFT member
         if !members.contains(&seal.get_info().get_signer_id().to_vec()) {
             return Err(PbftError::InvalidMessage(format!(
-                "Consensus seal is signed by an unknown peer: {:?}",
-                seal.get_info().get_signer_id()
+                "Consensus seal is signed by an unknown peer: {:?} members: {:?}",
+                seal.get_info().get_signer_id(), members
             )));
         }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -330,7 +330,7 @@ impl PbftNode {
         // We should add those to the log, if this is a commit for some other
         // block though, we ignore it like the rest
         if msg.get_block_id() == state.chain_head {
-            self.msg_log.add_message(msg.clone());
+            self.msg_log.add_message(msg);
             return Ok(());
         }
         // Check that the message is for the current view
@@ -342,7 +342,7 @@ impl PbftNode {
             )));
         }
 
-        self.msg_log.add_message(msg.clone());
+        self.msg_log.add_message(msg);
 
         // If this message is for the current sequence number and the node is in the Committing
         // phase, check if the node is ready to commit the block
@@ -1190,6 +1190,9 @@ impl PbftNode {
         let bytes = commit.write_to_bytes().map_err(|err| {
             PbftError::SerializationError("Error writing commit to bytes".into(), err)
         })?;
+
+        self.msg_log
+            .add_message(ParsedMessage::from_pbft_message(commit)?);
 
         self.service
             .send_to(

--- a/src/node.rs
+++ b/src/node.rs
@@ -818,6 +818,19 @@ impl PbftNode {
             self.msg_log.add_message(message.clone());
         }
 
+        //On startup the validator may send BlockValid for the chain head
+        // We should skip asking for a commit of this one, since it will
+        // never happen.
+        if seal.block_id == state.chain_head {
+            info!(
+                "{}: Block {} is the chain head, skipping commit and incrementing seq_num",
+                state,
+                hex::encode(&seal.block_id)
+            );
+            state.seq_num += 1;
+            return Ok(());
+        }
+
         // Commit the block, stop the idle timeout, and skip straight to Finishing
         self.service
             .commit_block(seal.block_id.clone())

--- a/src/node.rs
+++ b/src/node.rs
@@ -139,10 +139,20 @@ impl PbftNode {
             && msg_type != PbftMessageType::NewView
             && msg_type != PbftMessageType::SealRequest
         {
-            debug!(
-                "{}: Node is view changing; ignoring {} message",
-                state, msg_type
-            );
+            // If this is a commit message for the chain head, we shouldn't ignore it, since we may
+            // need it in the log
+            if msg_type == PbftMessageType::Commit && msg.get_block_id() == state.chain_head {
+                debug!(
+                    "{}: Node is view changing but this is a commit of the chain head; accepting {} message",
+                    state, msg_type
+                );
+                self.handle_commit(msg, state)?
+            } else {
+                debug!(
+                    "{}: Node is view changing; ignoring {} message",
+                    state, msg_type
+                );
+            }
             return Ok(());
         }
 
@@ -314,6 +324,14 @@ impl PbftNode {
         let info = msg.info().clone();
         let block_id = msg.get_block_id();
 
+        // Bootstrap commits for the chain head can come in on a prior view
+        // from where we are right now or the same view.
+        // We should add those to the log, if this is a commit for some other
+        // block though, we ignore it like the rest
+        if msg.get_block_id() == state.chain_head {
+            self.msg_log.add_message(msg.clone());
+            return Ok(());
+        }
         // Check that the message is for the current view
         if msg.info().get_view() != state.view {
             return Err(PbftError::InvalidMessage(format!(

--- a/src/node.rs
+++ b/src/node.rs
@@ -1615,7 +1615,8 @@ impl PbftNode {
         if !members.contains(&seal.get_info().get_signer_id().to_vec()) {
             return Err(PbftError::InvalidMessage(format!(
                 "Consensus seal is signed by an unknown peer: {:?} members: {:?}",
-                seal.get_info().get_signer_id(), members
+                seal.get_info().get_signer_id(),
+                members
             )));
         }
 

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -29,6 +29,15 @@ pub fn mock_config(num_nodes: u8) -> PbftConfig {
     config
 }
 
+/// Create a mock configuration given a number of nodes
+/// and with strict_quorum value as passed
+pub fn mock_config_with_strict_quorum(num_nodes: u8) -> PbftConfig {
+    let mut config = PbftConfig::default();
+    config.members = (0..num_nodes).map(|id| vec![id as u8]).collect();
+    config.strict_quorum = true;
+    config
+}
+
 /// Create a Block for the given block number
 pub fn mock_block(num: u8) -> Block {
     let previous_id = if num == 0 { vec![] } else { vec![num - 1] };


### PR DESCRIPTION
Adds a setting "sawtooth.consensus.pbft.strict_quorum"
which defaults to false.
Adds a method to PbftState::minimum_quorum which calculates
the minimum number of votes required to achieve consensus.
minimum_quorum behaves differently depending on the value
of strict_quorum.  If true, then minimum_quorum is n-f.
If false then minimum_quorum is 2f+1 except where n=6,
where minumum quorum is 4.
Leader's PrePrepare messages are now effectively counted
as its Prepare vote.

Signed-off-by: Kevin O'Donnell <kevin@blockchaintp.com>